### PR TITLE
Fix handling of 403 when application hangs

### DIFF
--- a/src/ducks/acme-accounts-epics.ts
+++ b/src/ducks/acme-accounts-epics.ts
@@ -116,6 +116,7 @@ const revokeAcmeAccount: AppEpic = (action$, state$, deps) => {
             map(
                () => slice.actions.revokeAcmeAccountSuccess({ acmeProfileUuid: action.payload.acmeProfileUuid, uuid: action.payload.uuid })
             ),
+
             catchError(
                err => of(slice.actions.revokeAcmeAccountFailed({ error: extractError(err, "Failed to revoke ACME Account") }))
             )
@@ -219,8 +220,8 @@ const disableAcmeAccount: AppEpic = (action$, state$, deps) => {
             map(
                () => slice.actions.disableAcmeAccountSuccess({ uuid: action.payload.uuid })
             ),
-            catchError(
 
+            catchError(
                err => of(slice.actions.disableAcmeAccountFailed({ error: extractError(err, "Failed to disable ACME Account") }))
             )
 
@@ -260,6 +261,7 @@ const bulkRevokeAcmeAccounts: AppEpic = (action$, state$, deps) => {
             map(
                () => slice.actions.bulkRevokeAcmeAccountsSuccess({ uuids: action.payload.uuids })
             ),
+
             catchError(
                err => of(slice.actions.bulkRevokeAcmeAccountsFailed({ error: extractError(err, "Failed to revoke ACME Accounts") }))
             )
@@ -269,9 +271,6 @@ const bulkRevokeAcmeAccounts: AppEpic = (action$, state$, deps) => {
       )
 
    );
-
-
-
 
 }
 
@@ -306,6 +305,7 @@ const bulkEnableAcmeAccounts: AppEpic = (action$, state$, deps) => {
             map(
                () => slice.actions.bulkEnableAcmeAccountsSuccess({ uuids: action.payload.uuids })
             ),
+
             catchError(
                err => of(slice.actions.bulkEnableAcmeAccountsFailed({ error: extractError(err, "Failed to enable ACME Accounts") }))
             )
@@ -349,6 +349,7 @@ const bulkDisableAcmeAccounts: AppEpic = (action$, state$, deps) => {
             map(
                () => slice.actions.bulkDisableAcmeAccountsSuccess({ uuids: action.payload.uuids })
             ),
+
             catchError(
                err => of(slice.actions.bulkDisableAcmeAccountsFailed({ error: extractError(err, "Failed to disable ACME Accounts") }))
             )

--- a/src/ducks/acme-profiles-epics.ts
+++ b/src/ducks/acme-profiles-epics.ts
@@ -24,11 +24,11 @@ const listAcmeProfiles: AppEpic = (action$, state$, deps) => {
             map(
                acmeProfiles => slice.actions.listAcmeProfilesSuccess(
                   { acmeProfileList: acmeProfiles.map(transformAcmeProfileListDtoToModel) }
-               ),
-               catchError(
-                  err => of(slice.actions.listAcmeProfilesFailed({ error: extractError(err, "Failed to get ACME Profiles list") }))
-
                )
+            ),
+
+            catchError(
+               err => of(slice.actions.listAcmeProfilesFailed({ error: extractError(err, "Failed to get ACME Profiles list") }))
             )
 
          )
@@ -71,6 +71,7 @@ const getAcmeProfileDetail: AppEpic = (action$, state$, deps) => {
             map(
                detail => slice.actions.getAcmeProfileSuccess({ acmeProfile: transformAcmeProfileDtoToModel(detail) })
             ),
+
             catchError(
                err => of(slice.actions.getAcmeProfileFailed({ error: extractError(err, "Failed to get ACME Profile details") }))
             )
@@ -129,6 +130,7 @@ const createAcmeProfile: AppEpic = (action$, state$, deps) => {
             map(
                obj => slice.actions.createAcmeProfileSuccess({ uuid: obj.uuid }),
             ),
+
             catchError(
                err => of(slice.actions.createAcmeProfileFailed({ error: extractError(err, "Failed to create ACME Profile") }))
             )
@@ -210,6 +212,7 @@ const updateAcmeProfile: AppEpic = (action$, state$, deps) => {
             map(
                acmeProfile => slice.actions.updateAcmeProfileSuccess({ acmeProfile: transformAcmeProfileDtoToModel(acmeProfile) })
             ),
+
             catchError(
                err => of(slice.actions.updateAcmeProfileFailed({ error: extractError(err, "Failed to update ACME Profile") }))
             )
@@ -274,6 +277,7 @@ const deleteAcmeProfile: AppEpic = (action$, state$, deps) => {
             map(
                () => slice.actions.deleteAcmeProfileSuccess({ uuid: action.payload.uuid })
             ),
+
             catchError(
                err => of(slice.actions.deleteAcmeProfileFailed({ error: extractError(err, "Failed to delete ACME Profile") }))
             )
@@ -337,6 +341,7 @@ const enableAcmeProfile: AppEpic = (action$, state$, deps) => {
             map(
                () => slice.actions.enableAcmeProfileSuccess({ uuid: action.payload.uuid })
             ),
+
             catchError(
                err => of(slice.actions.enableAcmeProfileFailed({ error: extractError(err, "Failed to enable ACME Profile") }))
             )
@@ -379,10 +384,9 @@ const disableAcmeProfile: AppEpic = (action$, state$, deps) => {
             map(
                () => slice.actions.disableAcmeProfileSuccess({ uuid: action.payload.uuid })
             ),
+
             catchError(
-
                err => of(slice.actions.disableAcmeProfileFailed({ error: extractError(err, "Failed to disable ACME Profile") }))
-
             )
 
          )
@@ -425,6 +429,7 @@ const bulkDeleteAcmeProfiles: AppEpic = (action$, state$, deps) => {
             map(
                errors => slice.actions.bulkDeleteAcmeProfilesSuccess({ uuids: action.payload.uuids, errors })
             ),
+
             catchError(
                err => of(slice.actions.bulkDeleteAcmeProfilesFailed({ error: extractError(err, "Failed to delete ACME Accounts") }))
             )
@@ -469,6 +474,7 @@ const bulkForceDeleteAcmeProfiles: AppEpic = (action$, state$, deps) => {
             map(
                () => slice.actions.bulkForceDeleteAcmeProfilesSuccess({ uuids: action.payload.uuids, redirect: action.payload.redirect })
             ),
+
             catchError(
                err => of(slice.actions.bulkForceDeleteAcmeProfilesFailed({ error: extractError(err, "Failed to delete ACME Accounts") }))
             )
@@ -531,6 +537,7 @@ const bulkEnableAcmeProfiles: AppEpic = (action$, state$, deps) => {
             map(
                () => slice.actions.bulkEnableAcmeProfilesSuccess({ uuids: action.payload.uuids })
             ),
+
             catchError(
                err => of(slice.actions.bulkEnableAcmeProfilesFailed({ error: extractError(err, "Failed to enable ACME Accounts") }))
             )
@@ -574,6 +581,7 @@ const bulkDisableAcmeProfiles: AppEpic = (action$, state$, deps) => {
             map(
                () => slice.actions.bulkDisableAcmeProfilesSuccess({ uuids: action.payload.uuids })
             ),
+
             catchError(
                err => of(slice.actions.bulkDisableAcmeProfilesFailed({ error: extractError(err, "Failed to disable ACME Accounts") }))
             )

--- a/src/ducks/audit-epics.ts
+++ b/src/ducks/audit-epics.ts
@@ -78,7 +78,9 @@ const listObjects: AppEpic = (action$, state, deps) => {
                objectList => slice.actions.listObjectsSuccess({ objectList })
             ),
 
-            catchError(err => of(slice.actions.listObjectsFailure({ error: extractError(err, "Failed to get objects list") })))
+            catchError(
+               err => of(slice.actions.listObjectsFailure({ error: extractError(err, "Failed to get objects list") }))
+            )
 
          )
 

--- a/src/ducks/authorities-epics.ts
+++ b/src/ducks/authorities-epics.ts
@@ -74,6 +74,7 @@ const getAuthorityDetail: AppEpic = (action$, state$, deps) => {
             map(
                authorityDto => slice.actions.getAuthorityDetailSuccess({ authority: transformAuthorityDtoToModel(authorityDto) })
             ),
+
             catchError(
                err => of(slice.actions.getAuthorityDetailFailure({ error: extractError(err, "Failed to get Authority detail") }))
             )
@@ -119,11 +120,11 @@ const listAuthorityProviders: AppEpic = (action$, state, deps) => {
                   connectors: providers.map(transformConnectorDTOToModel)
                })
             ),
-            catchError((err) =>
-               of(
-                  slice.actions.listAuthorityProvidersFailure({ error: extractError(err, "Failed to get Authority Provider list") })
-               )
+
+            catchError(
+               (err) =>of(slice.actions.listAuthorityProvidersFailure({ error: extractError(err, "Failed to get Authority Provider list") }))
             )
+
          )
       )
    );
@@ -163,6 +164,7 @@ const getAuthorityProviderAttributesDescriptors: AppEpic = (action$, state, deps
                   attributeDescriptor: attributeDescriptors.map(transformAttributeDescriptorDTOToModel)
                })
             ),
+
             catchError(
                err => of(slice.actions.getAuthorityProviderAttributeDescriptorsFailure({ error: extractError(err, "Failed to get Authority Provider Attribute Descriptor list") }))
             )
@@ -199,6 +201,7 @@ const getRAProfilesAttributesDescriptors: AppEpic = (action$, state, deps) => {
          slice.actions.getRAProfilesAttributesDescriptors.match
       ),
       switchMap(
+
          action => deps.apiClients.authorities.listRAProfileAttributesDescriptors(action.payload.authorityUuid).pipe(
 
             map(
@@ -207,6 +210,7 @@ const getRAProfilesAttributesDescriptors: AppEpic = (action$, state, deps) => {
                   attributesDescriptors: descriptors.map(transformAttributeDescriptorDTOToModel)
                })
             ),
+
             catchError(
                err => of(slice.actions.getRAProfilesAttributesDescriptorsFailure({ error: extractError(err, "Failed to get RA Profile Attribute Descriptor list") }))
             )
@@ -254,6 +258,7 @@ const createAuthority: AppEpic = (action$, state$, deps) => {
             map(
                obj => slice.actions.createAuthoritySuccess({ uuid: obj.uuid })
             ),
+
             catchError(
                err => of(slice.actions.createAuthorityFailure({ error: extractError(err, "Failed to create Authority") }))
             )
@@ -322,6 +327,7 @@ const updateAuthority: AppEpic = (action$, state$, deps) => {
             map(
                authorityDto => slice.actions.updateAuthoritySuccess({ authority: transformAuthorityDtoToModel(authorityDto) })
             ),
+
             catchError(
                err => of(slice.actions.updateAuthorityFailure({ error: extractError(err, "Failed to update Authority") }))
             )
@@ -386,6 +392,7 @@ const deleteAuthority: AppEpic = (action$, state$, deps) => {
             map(
                () => slice.actions.deleteAuthoritySuccess({ uuid: action.payload.uuid })
             ),
+
             catchError(
                err => of(slice.actions.deleteAuthorityFailure({ error: extractError(err, "Failed to delete Authority") }))
             )
@@ -450,6 +457,7 @@ const bulkDeleteAuthority: AppEpic = (action$, state$, deps) => {
             map(
                errors => slice.actions.bulkDeleteAuthoritySuccess({ uuids: action.payload.uuids, errors })
             ),
+
             catchError(
                err => of(slice.actions.bulkDeleteAuthorityFailure({ error: extractError(err, "Failed to bulk delete Authorities") }))
             )
@@ -494,6 +502,7 @@ const bulkForceDeleteAuthority: AppEpic = (action$, state$, deps) => {
             map(
                () => slice.actions.bulkForceDeleteAuthoritySuccess({ uuids: action.payload.uuids, redirect: action.payload.redirect })
             ),
+
             catchError(
                err => of(slice.actions.bulkForceDeleteAuthorityFailure({ error: extractError(err, "Failed to bulk force delete Authorities") }))
             )

--- a/src/ducks/certificates-epic.ts
+++ b/src/ducks/certificates-epic.ts
@@ -39,7 +39,9 @@ const listCertificates: AppEpic = (action$, state, deps) => {
                   })
                ),
 
-               catchError(err => of(slice.actions.listCertificatesFailure({ error: extractError(err, "Failed to get certificates list") })))
+               catchError(
+                  err => of(slice.actions.listCertificatesFailure({ error: extractError(err, "Failed to get certificates list") }))
+               )
 
             )
          }
@@ -81,6 +83,7 @@ const getCertificateDetail: AppEpic = (action$, state, deps) => {
             map(
                certificate => slice.actions.getCertificateDetailSuccess({ certificate: transformCertDTOToModel(certificate) })
             ),
+
             catchError(
                err => of(slice.actions.getCertificateDetailFailure({ error: extractError(err, "Failed to get certificate detail") }))
             )
@@ -124,6 +127,7 @@ const getCertificateValidationResult: AppEpic = (action$, state, deps) => {
             map(
                result => slice.actions.getCertificateValidationResultSuccess(result)
             ),
+
             catchError(
                err => of(slice.actions.getCertificateValidationResultFailure({ error: extractError(err, "Failed to get certificate validation result") }))
             )
@@ -243,6 +247,7 @@ const revokeCertificate: AppEpic = (action$, state, deps) => {
             map(
                () => slice.actions.revokeCertificateSuccess({ uuid: action.payload.uuid })
             ),
+
             catchError(
                err => of(slice.actions.revokeCertificateFailure({ error: extractError(err, "Failed to revoke certificate") }))
             )
@@ -291,6 +296,7 @@ const renewCertificate: AppEpic = (action$, state, deps) => {
             map(
                operation => slice.actions.renewCertificateSuccess({ uuid: operation.uuid })
             ),
+
             catchError(
                err => of(slice.actions.renewCertificateFailure({ error: extractError(err, "Failed to renew certificate") }))
             )
@@ -355,6 +361,7 @@ const getAvailableCertificateFilters: AppEpic = (action$, state, deps) => {
                   availableCertificateFilters: filters.map(filter => transformAvailableCertificateFilterDTOToModel(filter))
                })
             ),
+
             catchError(
                err => of(slice.actions.getAvailableCertificateFiltersFailure({ error: extractError(err, "Failed to get available certificate filters") }))
             )
@@ -400,6 +407,7 @@ const getCertificateHistory: AppEpic = (action$, state, deps) => {
                   certificateHistory: records.map(record => transformCertificateHistoryDTOToModel(record))
                })
             ),
+
             catchError(
                err => of(slice.actions.getCertificateHistoryFailure({ error: extractError(err, "Failed to get certificate history") }))
             )
@@ -445,6 +453,7 @@ const listCertificateLocations: AppEpic = (action$, state, deps) => {
                   certificateLocations: locations.map(location => transformLocationDtoToModel(location))
                })
             ),
+
             catchError(
                err => of(slice.actions.listCertificateLocationsFailure({ error: extractError(err, "Failed to list certificate locations") }))
             )
@@ -488,6 +497,7 @@ const deleteCertificate: AppEpic = (action$, state, deps) => {
             map(
                () => slice.actions.deleteCertificateSuccess({ uuid: action.payload.uuid })
             ),
+
             catchError(
                err => of(slice.actions.deleteCertificateFailure({ error: extractError(err, "Failed to delete certificate") }))
             )
@@ -563,12 +573,14 @@ const updateGroup: AppEpic = (action$, state, deps) => {
                         group: transformGroupDtoToModel(group)
                      })
                   ),
+
                   catchError(
                      err => of(slice.actions.updateGroupFailure({ error: extractError(err, "Failed to update group") }))
                   )
 
                ),
             ),
+
             catchError(
                err => of(slice.actions.updateGroupFailure({ error: extractError(err, "Failed to update group") }))
             )
@@ -623,6 +635,7 @@ const updateRaProfile: AppEpic = (action$, state, deps) => {
                         raProfile: transformRaProfileDTOToCertificateModel(raProfile)
                      })
                   ),
+
                   catchError(
                      err => of(slice.actions.updateRaProfileFailure({ error: extractError(err, "Failed to update RA profile") }))
                   )
@@ -680,6 +693,7 @@ const updateOwner: AppEpic = (action$, state, deps) => {
                   owner: action.payload.owner
                }),
             ),
+
             catchError(
                err => of(slice.actions.updateOwnerFailure({ error: extractError(err, "Failed to update owner") }))
             )
@@ -740,13 +754,17 @@ const bulkUpdateGroup: AppEpic = (action$, state, deps) => {
 
                   ),
 
-                  catchError(err => of(slice.actions.updateOwnerFailure({ error: extractError(err, "Failed to bulk update update group") })))
+                  catchError(
+                     err => of(slice.actions.updateOwnerFailure({ error: extractError(err, "Failed to bulk update update group") }))
+                  )
 
                )
 
             ),
 
-            catchError(err => of(slice.actions.updateOwnerFailure({ error: extractError(err, "Failed to bulk update update group") })))
+            catchError(
+               err => of(slice.actions.updateOwnerFailure({ error: extractError(err, "Failed to bulk update update group") }))
+            )
 
          )
 
@@ -804,13 +822,17 @@ const bulkUpdateRaProfile: AppEpic = (action$, state, deps) => {
 
                   ),
 
-                  catchError(err => of(slice.actions.updateOwnerFailure({ error: extractError(err, "Failed to bulk update update RA profile") })))
+                  catchError(
+                     err => of(slice.actions.updateOwnerFailure({ error: extractError(err, "Failed to bulk update update RA profile") }))
+                  )
 
                )
 
             ),
 
-            catchError(err => of(slice.actions.updateOwnerFailure({ error: extractError(err, "Failed to bulk update update RA profile") })))
+            catchError(
+               err => of(slice.actions.updateOwnerFailure({ error: extractError(err, "Failed to bulk update update RA profile") }))
+            )
 
          )
 
@@ -864,7 +886,9 @@ const bulkUpdateOwner: AppEpic = (action$, state, deps) => {
 
             ),
 
-            catchError(err => of(slice.actions.updateOwnerFailure({ error: extractError(err, "Failed to bulk update update owner") })))
+            catchError(
+               err => of(slice.actions.updateOwnerFailure({ error: extractError(err, "Failed to bulk update update owner") }))
+            )
 
          )
 
@@ -916,7 +940,9 @@ const bulkDelete: AppEpic = (action$, state, deps) => {
 
             ),
 
-            catchError(err => of(slice.actions.bulkDeleteFailure({ error: extractError(err, "Failed to bulk delete certificates") })))
+            catchError(
+               err => of(slice.actions.bulkDeleteFailure({ error: extractError(err, "Failed to bulk delete certificates") }))
+            )
 
          )
 
@@ -969,13 +995,17 @@ const uploadCertificate: AppEpic = (action$, state, deps) => {
 
                   ),
 
-                  catchError(err => of(slice.actions.uploadCertificateFailure({ error: extractError(err, "Failed to upload certificate") })))
+                  catchError(
+                     err => of(slice.actions.uploadCertificateFailure({ error: extractError(err, "Failed to upload certificate") }))
+                  )
 
                )
 
             ),
 
-            catchError(err => of(slice.actions.uploadCertificateFailure({ error: extractError(err, "Failed to upload certificate") })))
+            catchError(
+               err => of(slice.actions.uploadCertificateFailure({ error: extractError(err, "Failed to upload certificate") }))
+            )
 
          )
 
@@ -1025,7 +1055,9 @@ const getIssuanceAttributes: AppEpic = (action$, state, deps) => {
 
             ),
 
-            catchError(err => of(slice.actions.getIssuanceAttributesFailure({ error: extractError(err, "Failed to get issuance attributes") })))
+            catchError(
+               err => of(slice.actions.getIssuanceAttributesFailure({ error: extractError(err, "Failed to get issuance attributes") }))
+            )
 
          )
 
@@ -1075,7 +1107,9 @@ const getRevocationAttributes: AppEpic = (action$, state, deps) => {
 
             ),
 
-            catchError(err => of(slice.actions.getRevocationAttributesFailure({ error: extractError(err, "Failed to get revocation attributes") })))
+            catchError(
+               err => of(slice.actions.getRevocationAttributesFailure({ error: extractError(err, "Failed to get revocation attributes") }))
+            )
 
          )
 
@@ -1118,6 +1152,7 @@ const checkCompliance: AppEpic = (action$, state$, deps) => {
             map(
                () => slice.actions.checkComplianceSuccess()
             ),
+
             catchError(
                err => of(slice.actions.checkComplianceFailed({ error: extractError(err, "Failed to check compliance") }))
 
@@ -1155,11 +1190,11 @@ const checkComplianceSuccess: AppEpic = (action$, state$, deps) => {
          slice.actions.checkComplianceSuccess.match
       ),
       map(
-
          action => alertActions.success("Compliance Check for the certificates initiated")
       )
 
    );
+
 }
 
 

--- a/src/ducks/compliance-profiles-epics.ts
+++ b/src/ducks/compliance-profiles-epics.ts
@@ -23,11 +23,12 @@ const listComplianceProfiles: AppEpic = (action$, state$, deps) => {
             map(
                complianceProfiles => slice.actions.listComplianceProfilesSuccess(
                   { complianceProfileList: complianceProfiles.map(transformComplianceProfileListDtoToModel) }
-               ),
-               catchError(
-                  err => of(slice.actions.listComplianceProfilesFailed({ error: extractError(err, "Failed to get Compliance Profiles list") }))
-
                )
+            ),
+
+            catchError(
+               err => of(slice.actions.listComplianceProfilesFailed({ error: extractError(err, "Failed to get Compliance Profiles list") }))
+
             )
 
          )
@@ -70,6 +71,7 @@ const getComplianceProfileDetail: AppEpic = (action$, state$, deps) => {
             map(
                detail => slice.actions.getComplianceProfileSuccess({ complianceProfile: transformComplianceProfileDtoToModel(detail) })
             ),
+
             catchError(
                err => of(slice.actions.getComplianceProfileFailed({ error: extractError(err, "Failed to get Compliance Profile details") }))
             )
@@ -117,6 +119,7 @@ const createComplianceProfile: AppEpic = (action$, state$, deps) => {
             map(
                obj => slice.actions.createComplianceProfileSuccess({ uuid: obj.uuid }),
             ),
+
             catchError(
                err => of(slice.actions.createComplianceProfileFailed({ error: extractError(err, "Failed to create Compliance Profile") }))
             )
@@ -180,6 +183,7 @@ const deleteComplianceProfile: AppEpic = (action$, state$, deps) => {
             map(
                () => slice.actions.deleteComplianceProfileSuccess({ uuid: action.payload.uuid })
             ),
+
             catchError(
                err => of(slice.actions.deleteComplianceProfileFailed({ error: extractError(err, "Failed to delete Compliance Profile") }))
             )
@@ -244,6 +248,7 @@ const bulkDeleteComplianceProfiles: AppEpic = (action$, state$, deps) => {
             map(
                errors => slice.actions.bulkDeleteComplianceProfilesSuccess({ uuids: action.payload.uuids, errors })
             ),
+
             catchError(
                err => of(slice.actions.bulkDeleteComplianceProfilesFailed({ error: extractError(err, "Failed to delete Compliance Accounts") }))
             )
@@ -288,6 +293,7 @@ const bulkForceDeleteComplianceProfiles: AppEpic = (action$, state$, deps) => {
             map(
                () => slice.actions.bulkForceDeleteComplianceProfilesSuccess({ uuids: action.payload.uuids, redirect: action.payload.redirect })
             ),
+
             catchError(
                err => of(slice.actions.bulkForceDeleteComplianceProfilesFailed({ error: extractError(err, "Failed to delete Compliance Accounts") }))
             )
@@ -361,6 +367,7 @@ const addRule: AppEpic = (action$, state$, deps) => {
                   rule: transformComplianceRuleDTOToModel(rule)
                })
             ),
+
             catchError(
                err => of(slice.actions.addRuleFailed({ error: extractError(err, "Failed to add rule to Compliance Profile") }))
             )
@@ -405,8 +412,17 @@ const addGroup: AppEpic = (action$, state$, deps) => {
          ).pipe(
 
             map(
-               () => slice.actions.addGroupSuccess({ uuid: action.payload.uuid, connectorUuid: action.payload.connectorUuid, kind: action.payload.kind, groupUuid: action.payload.groupUuid, connectorName: action.payload.connectorName, groupName: action.payload.groupName, description: action.payload.description })
+               () => slice.actions.addGroupSuccess({
+                  uuid: action.payload.uuid,
+                  connectorUuid: action.payload.connectorUuid,
+                  kind: action.payload.kind,
+                  groupUuid: action.payload.groupUuid,
+                  connectorName: action.payload.connectorName,
+                  groupName: action.payload.groupName,
+                  description: action.payload.description
+               })
             ),
+
             catchError(
                err => of(slice.actions.addGroupFailed({ error: extractError(err, "Failed to add group to Compliance Profile") }))
             )
@@ -472,7 +488,6 @@ const deleteRuleFailed: AppEpic = (action$, state$, deps) => {
          slice.actions.deleteRuleFailed.match
       ),
       map(
-
          action => alertActions.error(action.payload.error || "Unexpected error occurred")
       )
 
@@ -499,6 +514,7 @@ const deleteGroup: AppEpic = (action$, state$, deps) => {
             map(
                () => slice.actions.deleteGroupSuccess({ connectorUuid: action.payload.connectorUuid, kind: action.payload.kind, groupUuid: action.payload.groupUuid })
             ),
+
             catchError(
                err => of(slice.actions.deleteGroupFailed({ error: extractError(err, "Failed to delete group from Compliance Profile") }))
             )
@@ -519,7 +535,6 @@ const deleteGroupFailed: AppEpic = (action$, state$, deps) => {
          slice.actions.deleteGroupFailed.match
       ),
       map(
-
          action => alertActions.error(action.payload.error || "Unexpected error occurred")
       )
 
@@ -544,6 +559,7 @@ const associateRaProfile: AppEpic = (action$, state$, deps) => {
             map(
                () => slice.actions.associateRaProfileSuccess({ uuid: action.payload.uuid, raProfileUuids: action.payload.raProfileUuids })
             ),
+
             catchError(
                err => of(slice.actions.associateRaProfileFailed({ error: extractError(err, "Failed to associate RA Profile to Compliance Profile") }))
             )
@@ -589,6 +605,7 @@ const dissociateRaProfile: AppEpic = (action$, state$, deps) => {
             map(
                () => slice.actions.dissociateRaProfileSuccess({ uuid: action.payload.uuid, raProfileUuids: action.payload.raProfileUuids })
             ),
+
             catchError(
                err => of(slice.actions.dissociateRaProfileFailed({ error: extractError(err, "Failed to dissociate RA Profile from Compliance Profile") }))
             )
@@ -633,6 +650,7 @@ const getAssociatedRaProfiles: AppEpic = (action$, state$, deps) => {
             map(
                (raProfiles) => slice.actions.getAssociatedRaProfilesSuccess({ raProfiles: raProfiles })
             ),
+
             catchError(
                err => of(slice.actions.getAssociatedRaProfilesFailed({ error: extractError(err, "Failed to get associated RA Profiles") }))
             )
@@ -676,6 +694,7 @@ const getRules: AppEpic = (action$, state$, deps) => {
                map(
                   (rules) => slice.actions.listComplianceRulesSuccess(rules.map(transformComplianceConnectorRuleDTOToModel))
                ),
+
                catchError(
                   err => of(slice.actions.listComplianceRulesFailed({ error: extractError(err, "Failed to get compliance rules") }))
                )
@@ -719,6 +738,7 @@ const getGroups: AppEpic = (action$, state$, deps) => {
                map(
                   (groups) => slice.actions.listComplianceGroupsSuccess(groups.map(transformComplianceConnectorGroupDTOToModel))
                ),
+
                catchError(
                   err => of(slice.actions.listComplianceGroupsFailed({ error: extractError(err, "Failed to get compliance groups") }))
                )
@@ -762,6 +782,7 @@ const checkCompliance: AppEpic = (action$, state$, deps) => {
             map(
                () => slice.actions.checkComplianceSuccess()
             ),
+
             catchError(
                err => of(slice.actions.checkComplianceFailed({ error: extractError(err, "Failed to check compliance") }))
 
@@ -783,7 +804,6 @@ const checkComplianceFailed: AppEpic = (action$, state$, deps) => {
          slice.actions.checkComplianceFailed.match
       ),
       map(
-
          action => alertActions.error(action.payload.error || "Unexpected error occurred")
       )
 
@@ -799,14 +819,11 @@ const checkComplianceSuccess: AppEpic = (action$, state$, deps) => {
          slice.actions.checkComplianceSuccess.match
       ),
       map(
-
          action => alertActions.success("Compliance Check for the certificates initiated")
       )
 
    );
 }
-
-
 
 
 const epics = [

--- a/src/ducks/connectors-epic.ts
+++ b/src/ducks/connectors-epic.ts
@@ -27,10 +27,10 @@ const listConnectors: AppEpic = (action$, state, deps) => {
                list => slice.actions.listConnectorsSuccess({
                   connectorList: list.map(transformConnectorDTOToModel)
                }),
+            ),
 
-               catchError(
-                  err => of(slice.actions.listConnectorsFailure({ error: extractError(err, "Failed to get connector list") }))
-               )
+            catchError(
+               err => of(slice.actions.listConnectorsFailure({ error: extractError(err, "Failed to get connector list") }))
             )
 
          )
@@ -799,13 +799,17 @@ const callback: AppEpic = (action$, state, deps) => {
                }
             ),
 
-            catchError(err => of(slice.actions.callbackFailure({ callbackId: action.payload.callbackId, error: extractError(err, "Connector callback failure") })))
+            catchError(
+               err => of(slice.actions.callbackFailure({ callbackId: action.payload.callbackId, error: extractError(err, "Connector callback failure") }))
+            )
 
          )
 
       ),
 
-      catchError(err => of(slice.actions.callbackFailure({ callbackId: "", error: extractError(err, "Failed to perform connector callback") })))
+      catchError(
+         err => of(slice.actions.callbackFailure({ callbackId: "", error: extractError(err, "Failed to perform connector callback") }))
+      )
 
    )
 

--- a/src/ducks/credentials-epics.ts
+++ b/src/ducks/credentials-epics.ts
@@ -120,6 +120,7 @@ const listCredentialProviders: AppEpic = (action$, state, deps) => {
                   connectors: providers.map(transformConnectorDTOToModel)
                })
             ),
+
             catchError((err) =>
                of(
                   slice.actions.listCredentialProvidersFailure({ error: extractError(err, "Failed to get Credential Provider list") })
@@ -163,6 +164,7 @@ const getCredentialProviderAttributeDescriptors: AppEpic = (action$, state, deps
                   credentialProviderAttributesDescriptors: attributeDescriptors.map(transformAttributeDescriptorDTOToModel)
                })
             ),
+
             catchError(
                err => of(slice.actions.getCredentialProviderAttributesDescriptorsFailure({ error: extractError(err, "Failed to get Credential Provider Attribute Descriptor list") }))
             )
@@ -226,6 +228,7 @@ const createCredential: AppEpic = (action$, state, deps) => {
 const createCredentialSuccess: AppEpic = (action$, state, deps) => {
 
    return action$.pipe(
+
       filter(
          slice.actions.createCredentialSuccess.match
       ),
@@ -235,6 +238,7 @@ const createCredentialSuccess: AppEpic = (action$, state, deps) => {
             return EMPTY;
          }
       )
+
    )
 
 }
@@ -334,6 +338,7 @@ const updateCredential: AppEpic = (action$, state, deps) => {
                   credential: transformCredentialDtoToModel(credential)
                })
             ),
+
             catchError(
                err => of(slice.actions.updateCredentialFailure({ error: extractError(err, "Failed to update Credential") }))
             )
@@ -350,6 +355,7 @@ const updateCredential: AppEpic = (action$, state, deps) => {
 const updateCredentialSuccess: AppEpic = (action$, state, deps) => {
 
    return action$.pipe(
+
       filter(
          slice.actions.updateCredentialSuccess.match
       ),
@@ -359,6 +365,7 @@ const updateCredentialSuccess: AppEpic = (action$, state, deps) => {
             return EMPTY;
          }
       )
+
    )
 
 }
@@ -395,9 +402,7 @@ const bulkDeleteCredential: AppEpic = (action$, state, deps) => {
             ),
 
             catchError(
-
                err => of(slice.actions.bulkDeleteCredentialsFailure({ error: extractError(err, "Failed to update Credential") }))
-
             )
 
          )
@@ -419,7 +424,9 @@ const bulkDeleteCredentialFailure: AppEpic = (action$, state, deps) => {
       map(
          action => alertActions.error(action.payload.error || "Unexpected error occurred")
       )
+
    );
+
 }
 
 
@@ -436,6 +443,7 @@ const bulkForceDeleteCredentials: AppEpic = (action$, state, deps) => {
             map(
                () => slice.actions.bulkForceDeleteCredentialsSuccess({ uuids: action.payload.uuids })
             ),
+
             catchError(
                err => of(slice.actions.bulkForceDeleteCredentialsFailure({ error: extractError(err, "Failed to update Credential") }))
             )

--- a/src/ducks/discoveries-epics.ts
+++ b/src/ducks/discoveries-epics.ts
@@ -74,6 +74,7 @@ const getDiscoveryDetail: AppEpic = (action$, state$, deps) => {
             map(
                discoveryDto => slice.actions.getDiscoveryDetailSuccess({ discovery: transformDiscoveryDTOToModel(discoveryDto) })
             ),
+
             catchError(
                err => of(slice.actions.getDiscoveryDetailFailure({ error: extractError(err, "Failed to get Discovery detail") }))
             )
@@ -119,14 +120,17 @@ const listDiscoveryProviders: AppEpic = (action$, state, deps) => {
                   connectors: providers.map(transformConnectorDTOToModel)
                })
             ),
-            catchError((err) =>
-               of(
-                  slice.actions.listDiscoveryProvidersFailure({ error: extractError(err, "Failed to get Discovery Provider list") })
-               )
+
+            catchError(
+               err => of(slice.actions.listDiscoveryProvidersFailure({ error: extractError(err, "Failed to get Discovery Provider list") }))
             )
+
          )
+
       )
+
    );
+
 }
 
 const listDiscoveryProvidersFailure: AppEpic = (action$, state, deps) => {
@@ -163,6 +167,7 @@ const getDiscoveryProviderAttributesDescriptors: AppEpic = (action$, state, deps
                   attributeDescriptor: attributeDescriptors.map(transformAttributeDescriptorDTOToModel)
                })
             ),
+
             catchError(
                err => of(slice.actions.getDiscoveryProviderAttributeDescriptorsFailure({ error: extractError(err, "Failed to get Discovery Provider Attribute list") }))
             )
@@ -205,9 +210,11 @@ const createDiscovery: AppEpic = (action$, state$, deps) => {
             action.payload.connectorUuid,
             action.payload.attributes.map(transformAttributeModelToDTO),
          ).pipe(
+
             map(
                obj => slice.actions.createDiscoverySuccess({ uuid: obj.uuid })
             ),
+
             catchError(
                err => of(slice.actions.createDiscoveryFailure({ error: extractError(err, "Failed to create discovery") }))
             )
@@ -272,6 +279,7 @@ const deleteDiscovery: AppEpic = (action$, state$, deps) => {
             map(
                () => slice.actions.deleteDiscoverySuccess({ uuid: action.payload.uuid })
             ),
+
             catchError(
                err => of(slice.actions.deleteDiscoveryFailure({ error: extractError(err, "Failed to delete discovery") }))
             )
@@ -336,6 +344,7 @@ const bulkDeleteDiscovery: AppEpic = (action$, state$, deps) => {
             map(
                ()=> slice.actions.bulkDeleteDiscoverySuccess({ uuids: action.payload.uuids })
             ),
+
             catchError(
                err => of(slice.actions.bulkDeleteDiscoveryFailure({ error: extractError(err, "Failed to bulk delete Discoveries") }))
             )

--- a/src/ducks/entities-epics.ts
+++ b/src/ducks/entities-epics.ts
@@ -28,6 +28,7 @@ const listEntityProviders: AppEpic = (action$, state, deps) => {
                   providers: providers.map(transformConnectorDTOToModel)
                })
             ),
+
             catchError((err) =>
                of(
                   slice.actions.listEntityProvidersFailure({ error: extractError(err, "Failed to get Entity Provider list") })
@@ -72,6 +73,7 @@ const getEntityProviderAttributesDescriptors: AppEpic = (action$, state, deps) =
                   attributeDescriptor: attributeDescriptors.map(transformAttributeDescriptorDTOToModel)
                })
             ),
+
             catchError(
                err => of(slice.actions.getEntityProviderAttributeDescriptorsFailure({ error: extractError(err, "Failed to get Entity Provider Attribute Descriptor list") }))
             )
@@ -111,12 +113,11 @@ const listEntities: AppEpic = (action$, state$, deps) => {
          () => deps.apiClients.entities.listEntities().pipe(
 
             map(
-
                entities => slice.actions.listEntitiesSuccess(
                   entities.map(transformEntityDtoToModel)
                )
-
             ),
+
             catchError(
                err => of(slice.actions.listEntitiesFailure({ error: extractError(err, "Failed to get list of Entities") }))
             )
@@ -159,10 +160,9 @@ const getEntityDetail: AppEpic = (action$, state$, deps) => {
          action => deps.apiClients.entities.getEntityDetail(action.payload.uuid).pipe(
 
             map(
-
                entity => slice.actions.getEntityDetailSuccess({ entity: transformEntityDtoToModel(entity) })
-
             ),
+
             catchError(
                err => of(slice.actions.getEntityDetailFailure({ error: extractError(err, "Failed to get Entity detail") }))
             )
@@ -209,10 +209,9 @@ const addEntity: AppEpic = (action$, state$, deps) => {
          ).pipe(
 
             map(
-
                obj => slice.actions.addEntitySuccess({ uuid: obj.uuid })
-
             ),
+
             catchError(
 
                err => of(slice.actions.addEntityFailure({ error: extractError(err, "Failed to add Entity") }))
@@ -236,10 +235,12 @@ const addEntitySuccess: AppEpic = (action$, state$, deps) => {
          slice.actions.addEntitySuccess.match
       ),
       switchMap(
+
          action => {
             history.push(`./${action.payload.uuid}`);
             return EMPTY;
          }
+
       )
 
    );
@@ -278,14 +279,11 @@ const updateEntity: AppEpic = (action$, state$, deps) => {
          ).pipe(
 
             map(
-
                entity => slice.actions.updateEntitySuccess({ entity: transformEntityDtoToModel(entity) })
-
             ),
+
             catchError(
-
                err => of(slice.actions.updateEntityFailure({ error: extractError(err, "Failed to update Entity") }))
-
             )
 
          )
@@ -305,10 +303,12 @@ const updateEntitySuccess: AppEpic = (action$, state$, deps) => {
          slice.actions.addEntitySuccess.match
       ),
       switchMap(
+
          action => {
             history.push(`./detail/${action.payload.uuid}`);
             return EMPTY;
          }
+
       )
 
    );
@@ -345,15 +345,13 @@ const deleteEntity: AppEpic = (action$, state$, deps) => {
          action => deps.apiClients.entities.removeEntity(action.payload.uuid).pipe(
 
             map(
-
                () => slice.actions.deleteEntitySuccess({ uuid: action.payload.uuid, redirect: action.payload.redirect })
-
             ),
-
 
             catchError(
                err => of(slice.actions.deleteEntityFailure({ error: extractError(err, "Failed to delete Entity") }))
             )
+
          )
 
       )
@@ -412,14 +410,11 @@ const listLocationAttributeDescriptors: AppEpic = (action$, state$, deps) => {
          action => deps.apiClients.entities.listLocationAttributeDescriptors(action.payload.entityUuid).pipe(
 
             map(
-
                descriptors => slice.actions.listLocationAttributeDescriptorsSuccess({ descriptors: descriptors.map(transformAttributeDescriptorDTOToModel) })
-
             ),
+
             catchError(
-
                err => of(slice.actions.listLocationAttributeDescriptorsFailure({ error: extractError(err, "Failed to get Location Attribute Descriptors") }))
-
             )
 
          )

--- a/src/ducks/groups-epics.ts
+++ b/src/ducks/groups-epics.ts
@@ -151,10 +151,10 @@ const createGroupSuccess: AppEpic = (action$, state, deps) => {
 const createGroupFailure: AppEpic = (action$, state$, deps) => {
 
    return action$.pipe(
+
       filter(
          slice.actions.createGroupFailure.match
       ),
-
       map(
          action => alertActions.error(action.payload.error || "Unexpected error occurred")
       )

--- a/src/ducks/locations-epics.ts
+++ b/src/ducks/locations-epics.ts
@@ -27,6 +27,7 @@ const listLocations: AppEpic = (action$, state, deps) => {
                   locations: locations.map(transformLocationDtoToModel)
                })
             ),
+
             catchError(
                err => of(slice.actions.listLocationsFailure({ error: extractError(err, "Failed to get Location list") }))
             )
@@ -66,6 +67,7 @@ const getLocationDetail: AppEpic = (action$, state, deps) => {
             map(
                location => slice.actions.getLocationDetailSuccess({ location: transformLocationDtoToModel(location) })
             ),
+
             catchError(
                err => of(slice.actions.getLocationDetailFailure({ error: extractError(err, "Failed to get Location detail") }))
             )
@@ -255,6 +257,7 @@ const deleteLocation: AppEpic = (action$, state, deps) => {
             map(
                () => slice.actions.deleteLocationSuccess({ uuid: action.payload.uuid, redirect: action.payload.redirect })
             ),
+
             catchError(
                err => of(slice.actions.deleteLocationFailure({ error: extractError(err, "Failed to delete Location") }))
             )
@@ -321,6 +324,7 @@ const enableLocation: AppEpic = (action$, state, deps) => {
             map(
                () => slice.actions.enableLocationSuccess({ uuid: action.payload.uuid })
             ),
+
             catchError(
                err => of(slice.actions.enableLocationFailure({ error: extractError(err, "Failed to enable Location") }))
             )
@@ -364,6 +368,7 @@ const disableLocation: AppEpic = (action$, state, deps) => {
             map(
                () => slice.actions.disableLocationSuccess({ uuid: action.payload.uuid })
             ),
+
             catchError(
                err => of(slice.actions.disableLocationFailure({ error: extractError(err, "Failed to disable Location") }))
             )
@@ -407,6 +412,7 @@ const getPushAttributes: AppEpic = (action$, state, deps) => {
             map(
                attributes => slice.actions.getPushAttributesSuccess({ attributes: attributes.map(transformAttributeDescriptorDTOToModel) })
             ),
+
             catchError(
                err => of(slice.actions.getPushAttributesFailure({ error: extractError(err, "Failed to get Push Attributes") }))
             )
@@ -450,6 +456,7 @@ const getCSRAttributes: AppEpic = (action$, state, deps) => {
             map(
                attributes => slice.actions.getCSRAttributesSuccess({ attributes: attributes.map(transformAttributeDescriptorDTOToModel) })
             ),
+
             catchError(
                err => of(slice.actions.getCSRAttributesFailure({ error: extractError(err, "Failed to get CSR Attributes") }))
             )
@@ -498,6 +505,7 @@ const pushCertificate: AppEpic = (action$, state, deps) => {
             map(
                location => slice.actions.pushCertificateSuccess({ location: transformLocationDtoToModel(location) })
             ),
+
             catchError(
                err => of(slice.actions.pushCertificateFailure({ error: extractError(err, "Failed to push Certificate") }))
             )
@@ -547,6 +555,7 @@ const issueCertificate: AppEpic = (action$, state, deps) => {
             map(
                location => slice.actions.issueCertificateSuccess({ location: transformLocationDtoToModel(location) })
             ),
+
             catchError(
                err => of(slice.actions.issueCertificateFailure({ error: extractError(err, "Failed to issue Certificate") }))
             )
@@ -594,6 +603,7 @@ const autoRenewCertificate: AppEpic = (action$, state, deps) => {
             map(
                location => slice.actions.autoRenewCertificateSuccess({ location: transformLocationDtoToModel(location) })
             ),
+
             catchError(
                err => of(slice.actions.autoRenewCertificateFailure({ error: extractError(err, "Failed to auto-renew Certificate") }))
             )
@@ -641,6 +651,7 @@ const removeCertificate: AppEpic = (action$, state, deps) => {
             map(
                location => slice.actions.removeCertificateSuccess({ location: transformLocationDtoToModel(location) })
             ),
+
             catchError(
                err => of(slice.actions.removeCertificateFailure({ error: extractError(err, "Failed to remove Certificate") }))
             )

--- a/src/ducks/ra-profiles-epics.ts
+++ b/src/ducks/ra-profiles-epics.ts
@@ -830,6 +830,7 @@ const checkCompliance: AppEpic = (action$, state$, deps) => {
             map(
                () => slice.actions.checkComplianceSuccess()
             ),
+
             catchError(
                err => of(slice.actions.checkComplianceFailed({ error: extractError(err, "Failed to check compliance") }))
 
@@ -892,6 +893,7 @@ const associateRaProfile: AppEpic = (action$, state$, deps) => {
             map(
                () => slice.actions.associateRaProfileSuccess({ uuid: action.payload.uuid, complianceProfileUuid: action.payload.complianceProfileUuid, complianceProfileName: action.payload.complianceProfileName, description: action.payload.description })
             ),
+
             catchError(
                err => of(slice.actions.associateRaProfileFailed({ error: extractError(err, "Failed to associate RA Profile to Compliance Profile") }))
             )
@@ -912,7 +914,6 @@ const associateRaProfileFailed: AppEpic = (action$, state$, deps) => {
          slice.actions.associateRaProfileFailed.match
       ),
       map(
-
          action => alertActions.error(action.payload.error || "Unexpected error occurred")
       )
 
@@ -937,6 +938,7 @@ const dissociateRaProfile: AppEpic = (action$, state$, deps) => {
             map(
                () => slice.actions.dissociateRaProfileSuccess({ uuid: action.payload.uuid, complianceProfileUuid: action.payload.complianceProfileUuid, complianceProfileName: action.payload.complianceProfileName, description: action.payload.description })
             ),
+
             catchError(
                err => of(slice.actions.dissociateRaProfileFailed({ error: extractError(err, "Failed to dissociate RA Profile from Compliance Profile") }))
             )
@@ -957,7 +959,6 @@ const dissociateRaProfileFailed: AppEpic = (action$, state$, deps) => {
          slice.actions.dissociateRaProfileFailed.match
       ),
       map(
-
          action => alertActions.error(action.payload.error || "Unexpected error occurred")
       )
 

--- a/src/ducks/roles-epics.ts
+++ b/src/ducks/roles-epics.ts
@@ -22,11 +22,16 @@ const list: AppEpic = (action$, state, deps) => {
 
          () => deps.apiClients.roles.list().pipe(
 
-            map(list => slice.actions.listSuccess({ roles: list.map(role => transformRoleDTOToModel(role)) })),
+            map(
+               list => slice.actions.listSuccess({ roles: list.map(role => transformRoleDTOToModel(role)) })
+            ),
 
-            catchError(err => of(slice.actions.listFailure({ error: extractError(err, "Failed to get roles list") })))
+            catchError(
+               err => of(slice.actions.listFailure({ error: extractError(err, "Failed to get roles list") }))
+            )
 
          )
+
       )
 
    )
@@ -61,9 +66,13 @@ const getDetail: AppEpic = (action$, state, deps) => {
 
          action => deps.apiClients.roles.getDetail(action.payload.uuid).pipe(
 
-            map(role => slice.actions.getDetailSuccess({ role: transformRoleDetailDTOToModel(role) })),
+            map(
+               role => slice.actions.getDetailSuccess({ role: transformRoleDetailDTOToModel(role) })
+            ),
 
-            catchError(err => of(slice.actions.getDetailFailure({ error: extractError(err, "Failed to get role detail") })))
+            catchError(
+               err => of(slice.actions.getDetailFailure({ error: extractError(err, "Failed to get role detail") }))
+            )
 
          )
 
@@ -101,9 +110,13 @@ const create: AppEpic = (action$, state, deps) => {
 
          action => deps.apiClients.roles.create(action.payload.name, action.payload.description).pipe(
 
-            map(role => slice.actions.createSuccess({ role: transformRoleDetailDTOToModel(role) })),
+            map(
+               role => slice.actions.createSuccess({ role: transformRoleDetailDTOToModel(role) })
+            ),
 
-            catchError(err => of(slice.actions.createFailure({ error: extractError(err, "Failed to create role") })))
+            catchError(
+               err => of(slice.actions.createFailure({ error: extractError(err, "Failed to create role") }))
+            )
 
          )
 
@@ -168,9 +181,13 @@ const update: AppEpic = (action$, state, deps) => {
             action.payload.description
          ).pipe(
 
-            map(role => slice.actions.updateSuccess({ role: transformRoleDetailDTOToModel(role) })),
+            map(
+               role => slice.actions.updateSuccess({ role: transformRoleDetailDTOToModel(role) })
+            ),
 
-            catchError(err => of(slice.actions.updateFailure({ error: extractError(err, "Failed to update role") })))
+            catchError(
+               err => of(slice.actions.updateFailure({ error: extractError(err, "Failed to update role") }))
+            )
 
          )
 
@@ -230,9 +247,13 @@ const deleteRole: AppEpic = (action$, state, deps) => {
 
          action => deps.apiClients.roles.delete(action.payload.uuid).pipe(
 
-            map(() => slice.actions.deleteSuccess({ uuid: action.payload.uuid, redirect: action.payload.redirect })),
+            map(
+               () => slice.actions.deleteSuccess({ uuid: action.payload.uuid, redirect: action.payload.redirect })
+            ),
 
-            catchError(err => of(slice.actions.deleteFailure({ error: extractError(err, "Failed to delete role") })))
+            catchError(
+               err => of(slice.actions.deleteFailure({ error: extractError(err, "Failed to delete role") }))
+            )
 
          )
 
@@ -298,7 +319,9 @@ const getUsers: AppEpic = (action$, state, deps) => {
                })
             ),
 
-            catchError(err => of(slice.actions.getUsersFailure({ error: extractError(err, "Failed to get role users") })))
+            catchError(
+               err => of(slice.actions.getUsersFailure({ error: extractError(err, "Failed to get role users") }))
+            )
 
          )
 
@@ -339,7 +362,10 @@ const updateUsers: AppEpic = (action$, state, deps) => {
             map(
                role => slice.actions.updateUsersSuccess({ role: transformRoleDetailDTOToModel(role) })
             ),
-            catchError(err => of(slice.actions.updateUsersFailure({ error: extractError(err, "Failed to update role users") })))
+
+            catchError(
+               err => of(slice.actions.updateUsersFailure({ error: extractError(err, "Failed to update role users") }))
+            )
 
          )
 
@@ -406,7 +432,9 @@ const getPermissions: AppEpic = (action$, state, deps) => {
                })
             ),
 
-            catchError(err => of(slice.actions.getPermissionsFailure({ error: extractError(err, "Failed to get role permissions") })))
+            catchError(
+               err => of(slice.actions.getPermissionsFailure({ error: extractError(err, "Failed to get role permissions") }))
+            )
 
          )
 
@@ -447,12 +475,16 @@ const updatePermissions: AppEpic = (action$, state, deps) => {
             action.payload.permissions
          ).pipe(
 
-            map(permissions => slice.actions.updatePermissionsSuccess({
-               uuid: action.payload.uuid,
-               permissions: transformSubjectPermissionsDTOToModel(permissions)
-            })),
+            map(
+               permissions => slice.actions.updatePermissionsSuccess({
+                  uuid: action.payload.uuid,
+                  permissions: transformSubjectPermissionsDTOToModel(permissions)
+               })
+            ),
 
-            catchError(err => of(slice.actions.updatePermissionsFailure({ error: extractError(err, "Failed to update role permissions") })))
+            catchError(
+               err => of(slice.actions.updatePermissionsFailure({ error: extractError(err, "Failed to update role permissions") }))
+            )
 
          )
 

--- a/src/ducks/users-epics.ts
+++ b/src/ducks/users-epics.ts
@@ -24,9 +24,13 @@ const list: AppEpic = (action$, state, deps) => {
 
          () => deps.apiClients.users.list().pipe(
 
-            map(list => slice.actions.listSuccess({ users: list.map(transformUserDTOToModel) })),
+            map(
+               list => slice.actions.listSuccess({ users: list.map(transformUserDTOToModel) })
+            ),
 
-            catchError(err => of(slice.actions.listFailure({ error: extractError(err, "Failed to get user list") })))
+            catchError(
+               err => of(slice.actions.listFailure({ error: extractError(err, "Failed to get user list") }))
+            )
 
          )
       )
@@ -123,20 +127,24 @@ const createUser: AppEpic = (action$, state, deps) => {
                   action.payload.roles || []
                ).pipe(
 
-                  map(userDetailDTO => slice.actions.createSuccess({ user: transformUserDetailDTOToModel(userDetailDTO) })),
+                  map(
+                     userDetailDTO => slice.actions.createSuccess({ user: transformUserDetailDTOToModel(userDetailDTO) })
+                  ),
 
-                  catchError(err => of(slice.actions.createFailure({ error: extractError(err, "Failed to update user roles") })))
+                  catchError(
+                     err => of(slice.actions.createFailure({ error: extractError(err, "Failed to update user roles") }))
+                  )
 
                )
             ),
 
-            catchError(err => of(slice.actions.createFailure({ error: extractError(err, "Failed to create user") })))
+            catchError(
+               err => of(slice.actions.createFailure({ error: extractError(err, "Failed to create user") }))
+            )
 
          )
 
-      ),
-
-      catchError(err => of(slice.actions.createFailure({ error: extractError(err, "Failed to create user") }))),
+      )
 
    )
 
@@ -280,6 +288,7 @@ const deleteUser: AppEpic = (action$, state, deps) => {
             map(
                () => slice.actions.deleteUserSuccess({ uuid: action.payload.uuid, redirect: action.payload.redirect })
             ),
+
             catchError(
                err => of(slice.actions.deleteUserFailure({ error: extractError(err, "Failed to delete user") }))
             )


### PR DESCRIPTION
Perms:
 - handle 403 gracefully when received from BE
 - When select all in the custom table is checked, all items (including not currently visible) are selected what can be confusing