### PR TITLE
Fix attribute loading and display in edit entity form

### DIFF
--- a/src/components/Forms/EntityForm/index.tsx
+++ b/src/components/Forms/EntityForm/index.tsx
@@ -74,11 +74,10 @@ export default function EntityForm({
          if (init) {
             dispatch(entityActions.resetState());
             dispatch(connectorActions.clearCallbackData());
+            if (editMode && (!entitySelector || entitySelector.uuid !== params.id)) {
+               dispatch(entityActions.getEntityDetail({ uuid: params.id }));
+            }
             setInit(false);
-         }
-
-         if (editMode && (!entitySelector || entitySelector.uuid !== params.id)) {
-            dispatch(entityActions.getEntityDetail({ uuid: params.id }));
          }
 
          if (init) {

--- a/src/ducks/entities-epics.ts
+++ b/src/ducks/entities-epics.ts
@@ -237,7 +237,7 @@ const addEntitySuccess: AppEpic = (action$, state$, deps) => {
       switchMap(
 
          action => {
-            history.push(`./${action.payload.uuid}`);
+            history.push(`./detail/${action.payload.uuid}`);
             return EMPTY;
          }
 


### PR DESCRIPTION
When the entity edit button is clicked, the details are fetched more times and the data are overridden by the empty values. This PR fixes the issue