### PR TITLE
Remove multiselct option for certificates in location and fix state issue

### DIFF
--- a/src/components/CustomTable/index.tsx
+++ b/src/components/CustomTable/index.tsx
@@ -267,16 +267,7 @@ function CustomTable({
             return;
          }
 
-         const checkedRows = tblData.filter(
-
-            (row, index) => {
-               if (!hasPagination) return true;
-               if (pageSize === 0) return true;
-               return paginationData ? true : index >= (page - 1) * pageSize && index < page * pageSize;
-            }
-
-         ).map(row => row.id);
-
+         const checkedRows = tblData.slice((page - 1) * pageSize, page * pageSize).map(row => row.id);
 
          setTblCheckedRows(checkedRows);
          if (onCheckedRowsChanged) onCheckedRowsChanged(checkedRows);
@@ -428,9 +419,8 @@ function CustomTable({
 
          const columns = tblHeaders ? [...tblHeaders] : [];
 
-         if (hasCheckboxes && multiSelect) columns.unshift({ id: "__checkbox__", content: "", sortable: false, width: "0%" });
+         if (hasCheckboxes) columns.unshift({ id: "__checkbox__", content: "", sortable: false, width: "0%" });
          if (hasDetails) columns.unshift({ id: "details", content: "", sortable: false, width: "1%" });
-
          return columns.map(
 
             header => (
@@ -446,10 +436,10 @@ function CustomTable({
                      {
                         header.id === "__checkbox__" ? (
 
-                           hasAllCheckBox ? (
-                              <input type="checkbox" checked={tblCheckedRows.length === tblData.length && tblData.length > 0} onChange={onCheckAllCheckboxClick} />
+                           hasAllCheckBox && multiSelect? (
+                              <input type="checkbox" checked={tblCheckedRows.length === tblData.slice((page - 1) * pageSize, page * pageSize).length && tblData.length > 0} onChange={onCheckAllCheckboxClick} />
                            ) : (
-                              <>&nbsp;</>
+                              <>&nbsp;</> 
                            )
 
                         ) : header.sortable ? (
@@ -496,7 +486,7 @@ function CustomTable({
 
          )
       },
-      [tblHeaders, hasCheckboxes, multiSelect, hasAllCheckBox, hasDetails, onColumnSortClick, tblCheckedRows.length, tblData.length, onCheckAllCheckboxClick]
+      [tblHeaders, hasCheckboxes, multiSelect, hasAllCheckBox, hasDetails, onColumnSortClick, tblCheckedRows.length, tblData.length, tblData, onCheckAllCheckboxClick]
 
    );
 

--- a/src/pages/authorities/detail/index.tsx
+++ b/src/pages/authorities/detail/index.tsx
@@ -40,7 +40,7 @@ export default function AuthorityDetail() {
       () => {
 
          if (!params.id) return;
-
+         dispatch(actions.resetState());
          dispatch(actions.getAuthorityDetail({ uuid: params.id }));
 
       },

--- a/src/pages/entities/detail/index.tsx
+++ b/src/pages/entities/detail/index.tsx
@@ -38,6 +38,7 @@ export default function EntityDetail() {
       () => {
 
          if (!params.id) return;
+         dispatch(actions.resetState());
 
          dispatch(actions.getEntityDetail({ uuid: params.id }));
 

--- a/src/pages/locations/detail/index.tsx
+++ b/src/pages/locations/detail/index.tsx
@@ -519,6 +519,7 @@ export default function LocationDetail() {
                headers={certHeaders}
                data={certData}
                hasCheckboxes={true}
+               multiSelect={false}
                onCheckedRowsChanged={
                   (rows) => { setCertCheckedRows(rows as string[]) }
                }


### PR DESCRIPTION
This PR contains the following fixes:
- Removal of multiselect option in the certificate table under location details page
- Fixing state issue under entity and authority page that incorrectly displays attributes when editing