### PR TITLE
Hide Key format when the token profile is not selected

### DIFF
--- a/src/components/_pages/cryptographic-keys/form/index.tsx
+++ b/src/components/_pages/cryptographic-keys/form/index.tsx
@@ -426,7 +426,7 @@ export default function CryptographicKeyForm() {
                      </Field>
 
 
-                  { !editMode ? <Field name="type" validate={validateRequired()}>
+                  { tokenProfile && !editMode ? <Field name="type" validate={validateRequired()}>
 
                      {({ input, meta }) => (
 


### PR DESCRIPTION
Hide Key format when the token profile is not selected